### PR TITLE
Support reading spool with ASA control chars

### DIFF
--- a/native/CHANGELOG.md
+++ b/native/CHANGELOG.md
@@ -6,7 +6,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## Recent Changes
 
-- `c`: Striped ASA control characters when reading spool files. [#1100](https://github.com/zowe/zowex/pull/1100)
+- `c`: Stripped ASA control characters when reading spool files. [#114](https://github.com/zowe/zowex/issues/114)
 - `c`: Fixed `--local-encoding` being ignored when reading spool files. The source codepage was never copied to the `ZDS` struct passed to `zds_read`, so the conversion always fell back to the default source encoding (`UTF-8`). [#1097](https://github.com/zowe/zowex/pull/1097)
 - `c`: Fixed an issue where passing numeric values to the `encoding` or `local-encoding` arguments would result in an empty string, as their argument definitions did not enable string coercion. Now, values provided to these options are converted to strings to ensure proper codepage conversion. [#1095](https://github.com/zowe/zowex/issues/1095)
 - `c`: Added ESM (RACF or equivalent) certificate and key ring management to the `system` command group, migrating the `keyring-utilities` functionality (R_datalib and System SSL) into `zowex` as two subgroups: `system keyring create|delete|list|list-rings|count` and `system cert import|export|delete|show|connect|set-default|trust|rename|refresh`. [#1079](https://github.com/zowe/zowex/pull/1079)

--- a/native/CHANGELOG.md
+++ b/native/CHANGELOG.md
@@ -6,6 +6,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## Recent Changes
 
+- `c`: Striped ASA control characters when reading spool files. [#1100](https://github.com/zowe/zowex/pull/1100)
 - `c`: Fixed `--local-encoding` being ignored when reading spool files. The source codepage was never copied to the `ZDS` struct passed to `zds_read`, so the conversion always fell back to the default source encoding (`UTF-8`). [#1097](https://github.com/zowe/zowex/pull/1097)
 - `c`: Fixed an issue where passing numeric values to the `encoding` or `local-encoding` arguments would result in an empty string, as their argument definitions did not enable string coercion. Now, values provided to these options are converted to strings to ensure proper codepage conversion. [#1095](https://github.com/zowe/zowex/issues/1095)
 - `c`: Added ESM (RACF or equivalent) certificate and key ring management to the `system` command group, migrating the `keyring-utilities` functionality (R_datalib and System SSL) into `zowex` as two subgroups: `system keyring create|delete|list|list-rings|count` and `system cert import|export|delete|show|connect|set-default|trust|rename|refresh`. [#1079](https://github.com/zowe/zowex/pull/1079)
@@ -297,3 +298,4 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ## [Unreleased]
 
 - Initial release
+

--- a/native/c/test/zjb.test.cpp
+++ b/native/c/test/zjb.test.cpp
@@ -22,6 +22,7 @@
 using namespace ztst;
 
 void sleep_on_status(std::string status, std::string jobid);
+void wait_for_status(std::string status, std::string jobid);
 
 void zjb_tests()
 {
@@ -132,23 +133,34 @@ void zjb_tests()
                   ZJB zjb = {0};
                   std::string jobid;
 
-                  int rc = zjb_submit(&zjb, jcl, jobid);
+                  const std::string asa_jcl =
+                  "//ASASPOOL JOB IZUACCT\n"
+                  "//STEP01   EXEC PGM=IEBGENER\n"
+                  "//SYSPRINT DD SYSOUT=*\n"
+                  "//SYSIN    DD DUMMY\n"
+                  "//SYSUT2   DD SYSOUT=*,DCB=(RECFM=FBA,LRECL=80)\n"
+                  "//SYSUT1   DD *\n"
+                  "1*** PAGE 1: HEADING ***\n"
+                  " THIS LINE IS SINGLE SPACED.\n"
+                  "0THIS LINE IS DOUBLE SPACED.\n"
+                  "/*\n";
+                  int rc = zjb_submit(&zjb, asa_jcl, jobid);
                   ExpectWithContext(rc, zjb.diag.e_msg).ToBe(RTNCD_SUCCESS);
 
                   std::string correlator = std::string(zjb.correlator, sizeof(zjb.correlator));
 
-                  sleep_on_status("INPUT", correlator);
-                  sleep_on_status("ACTIVE", correlator);
-
+                  sleep(5);
                   std::vector<ZJobDD> dds;
                   memset(&zjb, 0, sizeof(zjb));
                   rc = zjb_list_dds(&zjb, correlator, dds);
                   ExpectWithContext(rc, zjb.diag.e_msg).ToBe(RTNCD_SUCCESS);
                   Expect(dds.size()).ToBeGreaterThan(0);
 
-                  auto asa_dd = std::find_if(dds.begin(), dds.end(),
-                                              [](const ZJobDD &dd) -> bool
-                                              { return dd.is_asa; });
+                  auto asa_dd = std::find_if(dds.begin(), dds.end(), [](const ZJobDD &dd) { return dd.is_asa; });
+                  if (asa_dd == dds.end()) {
+                      std::string err_log;
+                      zjb_read_job_content_by_key(&zjb, correlator, 2, err_log);
+                  }
                   Expect(asa_dd != dds.end()).ToBe(true);
 
                   std::string content;
@@ -221,7 +233,7 @@ void sleep_on_status(std::string status, std::string jobid)
     }
     if (zjob.full_status == status)
     {
-      std::this_thread::sleep_for(std::chrono::milliseconds(10 * 5)); // wait for job to exit INPUT
+      std::this_thread::sleep_for(std::chrono::milliseconds(10 * 5));
     }
     else
     {

--- a/native/c/test/zjb.test.cpp
+++ b/native/c/test/zjb.test.cpp
@@ -149,6 +149,7 @@ void zjb_tests()
 
                   std::string correlator = std::string(zjb.correlator, sizeof(zjb.correlator));
 
+                  // Workaround for CONVERSION status issue; remove once resolved: https://github.com/zowe/zowex/issues/1101
                   sleep(5);
                   std::vector<ZJobDD> dds;
                   memset(&zjb, 0, sizeof(zjb));

--- a/native/c/test/zjb.test.cpp
+++ b/native/c/test/zjb.test.cpp
@@ -9,6 +9,7 @@
  *
  */
 
+#include <algorithm>
 #include <iostream>
 #include <stdexcept>
 
@@ -123,6 +124,50 @@ void zjb_tests()
                   memset(&zjb, 0, sizeof(zjb));
                   rc = zjb_read_job_jcl(&zjb, correlator, returned_jcl);
 
+                  ExpectWithContext(rc, zjb.diag.e_msg).ToBe(RTNCD_SUCCESS);
+                });
+
+             it("should detect ASA carriage control for spool DDs and read their content", [&]() -> void
+                {
+                  ZJB zjb = {0};
+                  std::string jobid;
+
+                  int rc = zjb_submit(&zjb, jcl, jobid);
+                  ExpectWithContext(rc, zjb.diag.e_msg).ToBe(RTNCD_SUCCESS);
+
+                  std::string correlator = std::string(zjb.correlator, sizeof(zjb.correlator));
+
+                  sleep_on_status("INPUT", correlator);
+                  sleep_on_status("ACTIVE", correlator);
+
+                  std::vector<ZJobDD> dds;
+                  memset(&zjb, 0, sizeof(zjb));
+                  rc = zjb_list_dds(&zjb, correlator, dds);
+                  ExpectWithContext(rc, zjb.diag.e_msg).ToBe(RTNCD_SUCCESS);
+                  Expect(dds.size()).ToBeGreaterThan(0); // expect at least one DD returned
+
+                  // JES-generated spool output (e.g. JESMSGLG) is dynamically
+                  // allocated and never catalogued, so it can only be detected
+                  // as ASA via JES's own DD metadata (ZJobDD::is_asa), not a
+                  // DSCB catalog lookup. At least one DD should report ASA.
+                  auto asa_dd = std::find_if(dds.begin(), dds.end(),
+                                              [](const ZJobDD &dd) -> bool
+                                              { return dd.is_asa; });
+                  Expect(asa_dd != dds.end()).ToBe(true);
+
+                  std::string content;
+                  memset(&zjb, 0, sizeof(zjb));
+                  rc = zjb_read_job_content_by_key(&zjb, correlator, asa_dd->key, content);
+                  ExpectWithContext(rc, zjb.diag.e_msg).ToBe(RTNCD_SUCCESS);
+                  Expect(content).Not().ToBe(""); // expect some content returned
+
+                  // The ASA carriage control byte should have been consumed to
+                  // produce line breaks, not left as a leading garbage byte on
+                  // each line (the bug this fix addresses).
+                  Expect(content.find('\n') != std::string::npos).ToBe(true);
+
+                  memset(&zjb, 0, sizeof(zjb));
+                  rc = zjb_delete(&zjb, correlator);
                   ExpectWithContext(rc, zjb.diag.e_msg).ToBe(RTNCD_SUCCESS);
                 });
 

--- a/native/c/test/zjb.test.cpp
+++ b/native/c/test/zjb.test.cpp
@@ -144,12 +144,8 @@ void zjb_tests()
                   memset(&zjb, 0, sizeof(zjb));
                   rc = zjb_list_dds(&zjb, correlator, dds);
                   ExpectWithContext(rc, zjb.diag.e_msg).ToBe(RTNCD_SUCCESS);
-                  Expect(dds.size()).ToBeGreaterThan(0); // expect at least one DD returned
+                  Expect(dds.size()).ToBeGreaterThan(0);
 
-                  // JES-generated spool output (e.g. JESMSGLG) is dynamically
-                  // allocated and never catalogued, so it can only be detected
-                  // as ASA via JES's own DD metadata (ZJobDD::is_asa), not a
-                  // DSCB catalog lookup. At least one DD should report ASA.
                   auto asa_dd = std::find_if(dds.begin(), dds.end(),
                                               [](const ZJobDD &dd) -> bool
                                               { return dd.is_asa; });
@@ -161,9 +157,6 @@ void zjb_tests()
                   ExpectWithContext(rc, zjb.diag.e_msg).ToBe(RTNCD_SUCCESS);
                   Expect(content).Not().ToBe(""); // expect some content returned
 
-                  // The ASA carriage control byte should have been consumed to
-                  // produce line breaks, not left as a leading garbage byte on
-                  // each line (the bug this fix addresses).
                   Expect(content.find('\n') != std::string::npos).ToBe(true);
 
                   memset(&zjb, 0, sizeof(zjb));

--- a/native/c/test/zjb.test.cpp
+++ b/native/c/test/zjb.test.cpp
@@ -149,8 +149,7 @@ void zjb_tests()
 
                   std::string correlator = std::string(zjb.correlator, sizeof(zjb.correlator));
 
-                  // Workaround for CONVERSION status issue; remove once resolved: https://github.com/zowe/zowex/issues/1101
-                  sleep(5);
+                  sleep(1);
                   std::vector<ZJobDD> dds;
                   memset(&zjb, 0, sizeof(zjb));
                   rc = zjb_list_dds(&zjb, correlator, dds);

--- a/native/c/test/zjb.test.cpp
+++ b/native/c/test/zjb.test.cpp
@@ -22,7 +22,6 @@
 using namespace ztst;
 
 void sleep_on_status(std::string status, std::string jobid);
-void wait_for_status(std::string status, std::string jobid);
 
 void zjb_tests()
 {

--- a/native/c/test/ztest.hpp
+++ b/native/c/test/ztest.hpp
@@ -39,7 +39,7 @@
 #include <regex>
 #include <functional>
 
-#define Expect(x) expect((x), EXPECT_CONTEXT{__LINE__, __FILE__, "", false})
+#define Expect(x) expect((x), EXPECT_CONTEXT{__LINE__, __FILE__, "", true})
 #define ExpectWithContext(x, context) expect((x), EXPECT_CONTEXT{__LINE__, __FILE__, std::string(context), true})
 #define TestLog(message) Globals::get_instance().test_log(message)
 #define TrimChars(str) Globals::get_instance().trim_chars(str)

--- a/native/c/zds.cpp
+++ b/native/c/zds.cpp
@@ -761,7 +761,15 @@ static std::string zds_resolve_dsname(const ZDSReadOpts &opts)
 
 static DscbAttributes zds_resolve_dscb(const ZDSReadOpts &opts)
 {
-  return opts.dsname.empty() ? DscbAttributes{} : zds_get_dscb_attributes(opts.dsname);
+  DscbAttributes attrs = opts.dsname.empty() ? DscbAttributes{} : zds_get_dscb_attributes(opts.dsname);
+  if (attrs.recfm.empty())
+  {
+    // Catalog lookup found nothing (e.g. an uncatalogued/dynamically
+    // allocated DD such as JES spool output) - fall back to the caller's
+    // hint, if any (e.g. JES's own DD metadata for spool output).
+    attrs.is_asa = opts.is_asa;
+  }
+  return attrs;
 }
 
 static std::string zds_resolve_write_target(const ZDSWriteOpts &opts)

--- a/native/c/zds.hpp
+++ b/native/c/zds.hpp
@@ -160,6 +160,7 @@ struct ZDSReadOpts
   ZDS *zds = nullptr;
   std::string ddname;
   std::string dsname;
+  bool is_asa = false;
 };
 
 /**

--- a/native/c/zjb.cpp
+++ b/native/c/zjb.cpp
@@ -33,6 +33,7 @@
 #include "zjbtype.h"
 #include "zdstype.h"
 #include "zdyn.h"
+#include "dcbd.h"
 #include "ihapsa.h"
 #include "cvt.h"
 #include "zdbg.h"
@@ -515,6 +516,7 @@ int zjb_read_job_content_by_dsn(ZJB *zjb, const std::string &dsn, std::string &r
 
   std::string parsed_jobid;
   int parsed_key = 0;
+  bool dd_is_asa = false;
 
   // parse dsn for jobid and key - if found, attempt to get the token for the dsn
   memset(zjb->token, 0, sizeof(zjb->token));
@@ -539,6 +541,7 @@ int zjb_read_job_content_by_dsn(ZJB *zjb, const std::string &dsn, std::string &r
       {
         ddname = dd.dsn;
         memcpy(zjb->token, dd.token, sizeof(dd.token));
+        dd_is_asa = dd.is_asa;
         found = true;
         break;
       }
@@ -562,7 +565,7 @@ int zjb_read_job_content_by_dsn(ZJB *zjb, const std::string &dsn, std::string &r
   zds.encoding_opts.data_type = zjb->encoding_opts.data_type;
   memcpy((void *)&zds.encoding_opts.codepage, (const void *)&zjb->encoding_opts.codepage, sizeof(zjb->encoding_opts.codepage));
 
-  ZDSReadOpts read_opts{.zds = &zds, .ddname = ddname, .dsname = dsn};
+  ZDSReadOpts read_opts{.zds = &zds, .ddname = ddname, .dsname = dsn, .is_asa = dd_is_asa};
   rc = zds_read(read_opts, response);
   memcpy(&zjb->diag, &zds.diag, sizeof(ZDIAG));
 
@@ -826,6 +829,7 @@ int zjb_list_dds(ZJB *zjb, const std::string &jobid, std::vector<ZJobDD> &jobDDs
     zjobdd.dsn = dsn;
     zjobdd.jobid = std::string(jobid);
     zjobdd.key = sysoutInfoNext[i].stvsdsky;
+    zjobdd.is_asa = (sysoutInfoNext[i].stvsrecf & dcbrecca) != 0;
 
     jobDDs.push_back(zjobdd);
   }

--- a/native/c/zjb.hpp
+++ b/native/c/zjb.hpp
@@ -41,6 +41,7 @@ struct ZJobDD
   std::string procstep;
   unsigned char token[80];
   int key;
+  bool is_asa = false;
 };
 
 /**


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Resolves customer bug where form feed asa characters were being added to job spool
<img width="1012" height="91" alt="image" src="https://github.com/user-attachments/assets/19e5ba7a-1bb1-4618-9270-c76565e38515" />


**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->
Open job spool -- JESMSGLG in editor and you should on longer see a form feed character at the beginning of the output

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
