### PR TITLE
Follow symlinks in `z:delete` script

### DIFF
--- a/scripts/buildTools.ts
+++ b/scripts/buildTools.ts
@@ -1431,7 +1431,9 @@ async function clean(connection: Client) {
 
 async function rmdir(connection: Client, sshProfile: IProfile) {
     console.log(
-        await runCommandInShell(connection, `rm -rf ${deployDirs.root}\n`, { stepName: "Removing deploy directory" }),
+        await runCommandInShell(connection, `rm -rf "$(realpath ${deployDirs.root})"\n`, {
+            stepName: "Removing deploy directory",
+        }),
     );
     console.log("Removal complete");
     const watcher = new WatchUtils(connection, sshProfile);


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
My deploy dir in `config.yaml` points to a symlink. Running `z:delete` removes the symlink rather than the directory behind it. This PR makes the `z:delete` script follow symlinks which I think is more expected behavior.

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
