### PR TITLE
chore: override dev deps to resolve audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2478,8 +2478,8 @@
       "license": "MIT"
     },
     "node_modules/fflate": {
-      "version": "0.8.2",
-      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "version": "0.8.3",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
       "dev": true,
       "license": "MIT"
     },
@@ -3225,8 +3225,8 @@
       "optional": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
**What It Does**

Updates resolved dev dependency versions for `nanoid` and `fflate` to resolve audit.

**How to Test**

`npm install && npm run audit` should not display any audit failures

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [ ] ~updated the changelog~ N/A (dev deps)
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)