### PR TITLE
chore: prep zo 1.0 release

### DIFF
--- a/native/CHANGELOG.md
+++ b/native/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the native code for "zowex" are documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
-## Recent Changes
+## `1.0.0`
 
 - **Breaking:** `c`: Renamed the `ZOWEX_NUM_WORKERS` environmental variable to `ZO_NUM_WORKERS`. [#1119](https://github.com/zowe/zowex/pull/1119)
 - **Breaking:** `c`: Renamed the `ZOWEX_LOG_LEVEL` environmental variable to `ZO_LOG_LEVEL`. [#1119](https://github.com/zowe/zowex/pull/1119)
@@ -323,4 +323,3 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ## [Unreleased]
 
 - Initial release
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zowex",
-  "version": "0.9.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zowex",
-      "version": "0.9.0",
+      "version": "1.0.0",
       "license": "EPL-2.0",
       "workspaces": [
         "packages/*"
@@ -4895,7 +4895,7 @@
     },
     "packages/cli": {
       "name": "zowex-for-zowe-cli",
-      "version": "0.9.0",
+      "version": "1.0.0",
       "bundleDependencies": [
         "@zowe/zos-uss-for-zowe-sdk",
         "@zowe/zowex-for-zowe-sdk",
@@ -4904,7 +4904,7 @@
       "license": "EPL-2.0",
       "dependencies": {
         "@zowe/zos-uss-for-zowe-sdk": "^8.24.0",
-        "@zowe/zowex-for-zowe-sdk": "0.9.0",
+        "@zowe/zowex-for-zowe-sdk": "1.0.0",
         "terminal-kit": "^3.1.2"
       },
       "devDependencies": {
@@ -4918,7 +4918,7 @@
     },
     "packages/sdk": {
       "name": "@zowe/zowex-for-zowe-sdk",
-      "version": "0.9.0",
+      "version": "1.0.0",
       "license": "EPL-2.0",
       "dependencies": {
         "base64-stream": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zowex",
-  "version": "0.9.0",
+  "version": "1.0.0",
   "private": true,
   "scripts": {
     "all": "npm run z:rebuild && concurrently \"npm run z:artifacts\" \"npm run build\"",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zowex-for-zowe-cli",
-  "version": "0.9.0",
+  "version": "1.0.0",
   "main": "lib/index.js",
   "scripts": {
     "build": "tsc -b",
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@zowe/zos-uss-for-zowe-sdk": "^8.24.0",
-    "@zowe/zowex-for-zowe-sdk": "0.9.0",
+    "@zowe/zowex-for-zowe-sdk": "1.0.0",
     "terminal-kit": "^3.1.2"
   },
   "devDependencies": {

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Client code for "@zowe/zowex-for-zowe-sdk" are docume
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
-## Recent Changes
+## `1.0.0`
 
 - **Breaking** The `zowex` program bundled in `server.pax.Z` is now renamed to `zo`. [#1119](https://github.com/zowe/zowex/pull/1119)
 - Added JSON-RPC support for listing parmlib data sets. [#1124](https://github.com/zowe/zowex/pull/1124)

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zowe/zowex-for-zowe-sdk",
-  "version": "0.9.0",
+  "version": "1.0.0",
   "main": "lib/index.js",
   "scripts": {
     "generate-constants": "tsx generateConstants.ts",

--- a/packages/sdk/src/ZSshConstants.ts
+++ b/packages/sdk/src/ZSshConstants.ts
@@ -10,4 +10,4 @@
  */
 
 // Generated via generateConstants.ts
-export const BUNDLED_SSH_SERVER_VERSION = "0.9.0";
+export const BUNDLED_SSH_SERVER_VERSION = "1.0.0";


### PR DESCRIPTION
**What It Does**

Prepares `zo` for `1.0.0` release

**How to Test**

- `npm i && npm run z:rebuild`
- test the build and see `zo` version 1.0

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)